### PR TITLE
Correct Helm deployment selector.matchLabels

### DIFF
--- a/helm/ffc-elm-plan-service/templates/deployment.yaml
+++ b/helm/ffc-elm-plan-service/templates/deployment.yaml
@@ -7,6 +7,10 @@ metadata:
 spec:
   replicas: {{ .Values.deployment.replicaCount }}
   minReadySeconds: {{ .Values.deployment.minReadySeconds }}
+  selector:
+    matchLabels:
+      app: {{ quote .Values.namespace }}
+      app.kubernetes.io/name: {{ quote .Values.name }}
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/helm/ffc-elm-plan-service/templates/service.yaml
+++ b/helm/ffc-elm-plan-service/templates/service.yaml
@@ -28,5 +28,4 @@ spec:
   selector:
     app: {{ quote .Values.namespace }}
     app.kubernetes.io/name: {{ quote .Values.name }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
   type: {{ quote .Values.service.type }}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ffc-elm-plan-service",
   "description": "",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "homepage": "https://github.com/DEFRA/ffc-elm-plan-service",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
If selector.matchLabels is not set, Kubernetes automatically copies
deployment template labels to selector.matchLabels. In this case,
including the version in the helm.sh/chart label, as recommended in
Helm best practices, causes upgrades to fail because
selector.matchLabels is immutable. To resolve this, specify matchLabels
by hand, excluding the chart label.