### PR TITLE
Use a unique rolebinding name

### DIFF
--- a/helm/ffc-elm-plan-service/templates/developer-rolebinding.yaml
+++ b/helm/ffc-elm-plan-service/templates/developer-rolebinding.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ .Values.workstream }}-developer-1-admin-rolebinding
+  name: {{ .Values.name }}-developer-1-admin-rolebinding
   namespace: {{ .Values.namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ffc-elm-plan-service",
   "description": "",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "homepage": "https://github.com/DEFRA/ffc-elm-plan-service",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This enables two projects to deploy with their own rolebindings into a
shared namespace.